### PR TITLE
2 kleine Fixes

### DIFF
--- a/epgcopy/src/plugin.py
+++ b/epgcopy/src/plugin.py
@@ -81,9 +81,12 @@ def myFtp():
     myPrint("epg.db was successfully transferred")
 
 class copyEveryDay(Screen):
+    instance = None
+
     def __init__(self, session):
         self.session = session
         Screen.__init__(self, session)
+        copyEveryDay.instance = self
         self.timer = eTimer()
         self.timer_conn = self.timer.timeout.connect(self.__doCopy)
         self.configChange()
@@ -167,6 +170,7 @@ class epgCopyScreen(Screen, ConfigListScreen):
       
     def saveSettings(self):
           config.plugins.epgCopy.save()
+          copyEveryDay.instance.configChange()
           self.close()
     
     def startManually(self):

--- a/epgcopy/src/plugin.py
+++ b/epgcopy/src/plugin.py
@@ -94,6 +94,7 @@ class copyEveryDay(Screen):
     def configChange(self, configElement = None):   
         if self.timer.isActive(): # stop timer if running
             self.timer.stop()
+        now = localtime()
         begin = int(mktime(
             (now.tm_year, now.tm_mon, now.tm_mday,
             config.plugins.epgCopy.copytime.value[0],


### PR DESCRIPTION
1) Wenn im Erweiterungsmenü die Zeit für tägliche Transfers geändert wurde, wurde diese bis zum enigma2 Neustart nicht übernommen.
2) Um den Timer für den täglichen Transfer zu berechnen, wurde "now" benutzt, das allerdings bereits gesetzt wurde, während das Plugin geladen wird. Dadurch wurde der Timer falsch berechnet und der Transfer ab dem 2. Tag viele male täglich gestartet.