### PR TITLE
Output space-separated tags correctly

### DIFF
--- a/autotimer/src/AutoTimerConfiguration.py
+++ b/autotimer/src/AutoTimerConfiguration.py
@@ -652,6 +652,8 @@ def buildConfig(defaultTimer, timers, webif = False):
 	# Tags
 	if webif and defaultTimer.tags:
 		extend(('  <e2tags>', stringToXML(' '.join(defaultTimer.tags)), '</e2tags>\n'))
+		for tag in defaultTimer.tags:
+			extend(('  <e2tag>', stringToXML(tag), '</e2tag>\n'))
 	else:
 		for tag in defaultTimer.tags:
 			extend(('  <tag>', stringToXML(tag), '</tag>\n'))

--- a/autotimer/src/AutoTimerConfiguration.py
+++ b/autotimer/src/AutoTimerConfiguration.py
@@ -804,6 +804,8 @@ def buildConfig(defaultTimer, timers, webif = False):
 		# Tags
 		if webif and timer.tags:
 			extend(('  <e2tags>', stringToXML(' '.join(timer.tags)), '</e2tags>\n'))
+			for tag in timer.tags:
+				extend(('  <e2tag>', stringToXML(tag), '</e2tag>\n'))
 		else:
 			for tag in timer.tags:
 				extend(('  <tag>', stringToXML(tag), '</tag>\n'))


### PR DESCRIPTION
Output space-separated tags correctly

This change outputs autotimer tags individually instead of providing a space-separated list which splits space-separated tags incorrectly.
<e2tags> is kept so as not to break existing consumers.