### PR TITLE
c3vocupdater: Handle mixed newline chars in bouquets.{tv,radio} (master)

### DIFF
--- a/c3vocupdater/src/c3voc.py
+++ b/c3vocupdater/src/c3voc.py
@@ -440,7 +440,7 @@ def update_streams_v2(url="https://streaming.media.ccc.de/streams/v2.json"):
 
         bouquets_tv_path = os.path.join(pkgsysconfdir, "bouquets.{}".format(mode_name.lower()))
         try:
-            fp = open(bouquets_tv_path, "a+")
+            fp = open(bouquets_tv_path)
         except OSError as exc:
             logging.error(exc)
             continue
@@ -453,11 +453,25 @@ def update_streams_v2(url="https://streaming.media.ccc.de/streams/v2.json"):
         line = service_line(ref)
 
         with fp:
-            fp.seek(0)
-            if line not in fp:
-                fp.write(line)
-                logging.info("Added bouquet '{}' to '{}'.".format(c3voc_title(), bouquets_tv_path))
-                changed = True
+            lines = fp.read().splitlines()
+
+        if line.rstrip() not in lines:
+            try:
+                fp = open(bouquets_tv_path, "w")
+            except OSError as exc:
+                logging.error(exc)
+                continue
+
+            lines.append(line)
+            with fp:
+                fp.write("\n".join(lines))
+
+            logging.info("Added bouquet '{}' to '{}'.".format(c3voc_title(), bouquets_tv_path))
+            changed = True
+        else:
+            logging.debug(
+                "Bouquet '{}' already present in '{}'.".format(c3voc_title(), bouquets_tv_path)
+            )
 
         if changed:
             eDVBDB.getInstance().reloadBouquets()


### PR DESCRIPTION
- If the line to add was already present with a differing (e.g. `\n` vs. `\r\n`) line ending, it would have been added a second time.
- If the file ended without a trailing newline, no newline was added before the newly added line.

To mitigate all of this, the complete file gets rewritten with uniform unix line endings, in case a line needs to get added.
